### PR TITLE
[feat] 메인페이지 캘린더 일정 보이기 및 필터 기능 구현 

### DIFF
--- a/src/main/resources/static/css/calendar.css
+++ b/src/main/resources/static/css/calendar.css
@@ -112,7 +112,7 @@ h2{
         events: events.map(function(event) {
             return {
                 title: event.name,
-                start: event.start_date,
+                start: _date,
                 backgroundColor: event.color,
                 textColor: "#ffffff"
             };
@@ -170,8 +170,8 @@ h2{
     font-size: 10px;
 }
 
-.fc-customDropdownMenu-button fc-button fc-button-primary {
-
+.customDropdownMenu {
+    left: 150px;
 }
 
 
@@ -271,15 +271,6 @@ li {
     width: 100%;
 }
 
-/*#myDropdownButton {*/
-/*    align-items: flex-start;*/
-/*}*/
-
-/*@media screen and (max-width: 768px) {*/
-/*    .content {*/
-/*        width: 100%;*/
-/*    }*/
-/*}*/
 
 @media screen and (max-width:500px){
     body {
@@ -311,23 +302,6 @@ li {
         font-weight: bold;
     }
 }
-/*@media screen and (max-height:500px){*/
-/*    body {*/
-/*        !*margin: 40px 10px;*!*/
-/*        padding: 0;*/
-/*        font-family: Arial, Helvetica Neue, Helvetica, sans-serif;*/
-/*        font-size: 11px;*/
-/*        height:100%;*/
-/*    }*/
-/*   */
-/*}*/
-
-
-/*.fc .fc-toolbar-title {*/
-/*    font-size: 2.3em;*/
-/*    !*margin: 0px;*!*/
-/*    font-weight: bold;*/
-/*}*/
 
 .fc-event {
     border: none !important; /* 일정의 테두리 제거 */
@@ -357,33 +331,6 @@ li {
     background-color: #ffffff;
     color: #414141;
 }
-
-
-/*.fc-daygrid-event-dot {*/
-/*    display: none;*/
-/*}*/
-
-
-/*.dropdown-menu {*/
-/*    display: none; !* 기본적으로 숨김 *!*/
-/*    position: absolute;*/
-/*    background-color: #f1f1f1;*/
-/*    min-width: 160px;*/
-/*    box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2);*/
-/*    z-index: 1;*/
-/*}*/
-
-/*.show {*/
-/*    display: block; !* 보이게 함 *!*/
-/*}*/
-
-/* 추가함! */
-/* 드롭다운(전체,개인,그룹) */
-/*.dropdown-toggle {*/
-/*    width: 8%;*/
-/*    min-width: 70px;*/
-/*    margin-bottom: 3px;*/
-/*}*/
 
 .fc .fc-highlight {
     /*background: var(--fc-highlight-color);*/

--- a/src/main/resources/static/css/calendar.css
+++ b/src/main/resources/static/css/calendar.css
@@ -1,5 +1,7 @@
 
-
+h2{
+    font-size: 30px;
+}
 .head {
     position: relative;
     display: flex;
@@ -21,26 +23,16 @@
     justify-content: space-between;
 }
 
-/* .withoutside i {
-
-  position: fixed;
-  top: 1.5%;
-  right: 1.2%;
-  z-index: 9999;
-  font-size: 1.6rem;
-  padding: .4rem .8rem;
-  background-color: #4FD1C5;
-  color: #ffffff;
-  border-radius: 2.5rem;
-} */
-
-.dropdown {
-    align-items: start;
-}
+/*.dropdown {*/
+/*    align-items: start;*/
+/*}*/
 
 .full-contentbox {
     display: flex;
     width: 100%;
+    font-style: normal;
+    font-family: "Nanum Gothic Coding", monospace;
+    font-weight: bold;
 }
 
 .withoutside {
@@ -57,28 +49,92 @@
     width: 100%;
     height: 100vh;
     /* flex-wrap: wrap; */
-    /* justify-content: space-between; */
+    /* justify-content: spa let calendar = new FullCalendar.Calendar(calendarEl, {
+        timeZone: 'UTC',
+        themeSystem: 'bootstrap5',
+        initialView: 'dayGridMonth',
+        // contentHeight: 600,
+        editable: true,  //  드래그해서 수정 가능한지, 길게 확장도 가능
+        selectable: true,
+        navLinks: false,  //  요일이랑 날짜 클릭 시 일이나 주단위 보여주는 화면으로 넘어감
+        select: function(info) {
+            // 클릭한 날짜 정보를 콘솔에 출력
+            console.log('Clicked date:', info.start);
+            // -> 확인용 코드
+            console.log(info);
+            // 클릭한 날짜에 해당하는 일정 가져오기
+            let selectedDate = info.start;
+            let selectedEvents = getEventsForDate(selectedDate);
+
+            // console.log(selectedEvents)
+            // 가져온 일정을 리스트 형식으로 보여주기
+            showEventsList(selectedEvents);
+
+            // 클릭한 날짜를 tit_date에 표시
+            let clickedDate = selectedDate.toISOString().slice(0, 10); // YYYY-MM-DD 형식으로 변환
+            $('.tit_date').text(clickedDate);
+        },
+
+        headerToolbar: {
+            start: 'today prev,next',
+            center: 'title',
+            right: 'customDropdownMenu'
+        },
+
+        customButtons: {
+            customDropdownMenu: {
+                text: '전체',
+                click: function() {
+                    $('#customDropdownMenu').toggleClass('show');
+                    // $('#customDropdownMenu').empty(); // 이전 내용 지우기
+
+                    // // 드롭다운 메뉴 항목 추가
+                    // $('#customDropdownMenu').append('<a class="dropdown-item" href="#">전체</a>');
+                    // $('#customDropdownMenu').append('<a class="dropdown-item" href="#">개인</a>');
+                    // $('#customDropdownMenu').append('<a class="dropdown-item" href="#">단체</a>');
+
+                    // 각 항목 클릭 시 이벤트 처리
+                    // $('.dropdown-item').click(function() {
+                    //     let text = $(this).text();
+                    //     $('.btn-secondary').text(text); // 버튼 텍스트 변경
+                    //     hideDropdownMenu(); // 드롭다운 닫기
+                    //
+                    // });
+                }
+            }
+        },
+
+
+        initialDate: today, // 달력 처음 로드될 때 표시되는 날짜, default 는 현재 날짜
+        editable: false,
+        dayMaxEvents: true, // +more 표시 전 최대 이벤트 갯수, true는 셀 높이에 의해 결정
+        eventLimit: true,
+        events: events.map(function(event) {
+            return {
+                title: event.name,
+                start: event.start_date,
+                backgroundColor: event.color,
+                textColor: "#ffffff"
+            };
+        }),
+
+    });
+
+    // 각 항목 클릭 시 이벤트 처리 (이벤트 위임을 사용하여 중복 바인딩을 방지합니다)
+    $('body').on('click', '.dropdown-item', function() {
+        let text = $(this).text();
+        $('.btn-secondary').text(text); // 버튼 텍스트 변경
+        hideDropdownMenu(); // 드롭다운 닫기
+    });
+
+    // dropdown 메뉴 숨기는 함수
+    function hideDropdownMenu() {
+        $('#customDropdownMenu').removeClass('show');
+    }
+
+    calendar.render();ce-between; */
     /* 소민 */
     /* min-width: 100px; */
-}
-
-.headforbutton {
-    display: flex;
-    justify-content: space-between;
-    height: 15vh;
-    margin-top: 1vh;
-}
-
-.headforbutton i {
-    position: fixed;
-    top: 1vh;
-    right: 1vh;
-    z-index: 10;
-    font-size: 1.6rem;
-    padding: .4rem .8rem;
-    background-color: #4FD1C5;
-    color: #ffffff;
-    border-radius: 2.5rem;
 }
 
 .main {
@@ -95,12 +151,29 @@
 #calendar {
     /* max-width: 1100px; */
     width: 100%;
-    height: 100%;
+    height: 100vh;
     /* max-height: 100%; */
     margin: 0 0 0 0 ;
     float: right;
     /* width: 100%; */
 }
+
+/* toolbar header 부분*/
+.fc .fc-header-toolbar {
+    margin-bottom: 1.3em;
+    margin-top: 1.3em;
+    margin-left: 10px; /* today 버튼 왼쪽 여백 */
+    margin-right: 10px; /* dropbox 버튼 오른쪽 여백 */
+}
+
+.fc-toolbar-title {
+    font-size: 10px;
+}
+
+.fc-customDropdownMenu-button fc-button fc-button-primary {
+
+}
+
 
 .agenda_wrap {
     /* 일정 상세 부분 */
@@ -108,37 +181,69 @@
     z-index: 6;
     order: 3;
     height: 100%;
-    width: 15%;
+    width: 20%;
     /* border-left: 1px solid #EBEBEB; */
     background-color: #ffffff;
     min-width: 100px;
-    border-left-style: solid;
-    border-left-width: 2px;
-    border-left-color: #EBEBEB;
+    /*border-left-style: solid;*/
+    /*border-left-width: 1px;*/
+    /*border-left-color: lightgrey;*/
 
 }
 
-ul,
+ul {
+    padding: 0 0 0 5px;
+    /*display: flex;*/
+    /*justify-content: start;*/
+    /*flex-direction: column;*/
+    /*list-style-type: none;*/
+    /*margin-bottom: 1rem;*/
+    /*font-size: 13px;*/
+}
 li {
     padding: 0 0 0 5px;
     display: flex;
     justify-content: start;
-    flex-direction : column;
+    flex-direction : row;
     list-style-type: none;
-    margin-bottom: 1rem;
+    /*margin-top: .5rem;*/
+    margin-bottom: .8rem;
+    font-size: 14px;
+    margin-right: 3px;
 }
 
 .area_agenda .area_date {
     display: flex;
     align-items: center;
     justify-content: start;
-    /* or start */
     width: 100%;
-    height: 57px;
+    height: 40px;
     padding: 0 0 0 14px;
     font-size: 12px;
     box-sizing: border-box;
+    margin-top: 83px;
+    border-top: 1px solid;
+    border-top-color: lightgrey;
+}
 
+/* 요일 */
+.fc-col-header-cell-cushion {
+    color: #494747;
+}
+/*.fc-col-header-cell-cushion:hover {*/
+/*    text-decoration: none;*/
+/*    color:#000;*/
+/*}*/
+
+/* 일자(숫자) */
+.fc-daygrid-day-number{
+    color: #494747;
+    font-size:1em;
+}
+
+/* 일정 시간, 일정명 */
+.fc-daygrid-dot-event > .fc-event-title{
+    color:#494747 !important;
 }
 
 /* 캘린더에서 시간 표시X */
@@ -146,7 +251,7 @@ li {
     display : none;
 }
 .tit_date {
-    font-size: medium;
+    font-size: 18px;
     font-weight: bold;
 }
 
@@ -166,22 +271,63 @@ li {
     width: 100%;
 }
 
-#myDropdownButton {
-    align-items: flex-start;
-}
+/*#myDropdownButton {*/
+/*    align-items: flex-start;*/
+/*}*/
 
-@media screen and (max-width: 768px) {
-    .content {
-        width: 100%;
+/*@media screen and (max-width: 768px) {*/
+/*    .content {*/
+/*        width: 100%;*/
+/*    }*/
+/*}*/
+
+@media screen and (max-width:500px){
+    body {
+        /*margin: 40px 10px;*/
+        padding: 0;
+        font-family: Arial, Helvetica Neue, Helvetica, sans-serif;
+        font-size: 11px;
+        height:100%;
+    }
+    .agenda_wrap {
+        position: relative;
+        top: 0;
+        margin-top: 20px; /* 캘린더와 사이 간격 조절 */
+    }
+    #calendar {
+        order: 2; /* 캘린더를 우선적으로 아래로 내리기 */
     }
 }
-
-
-.fc .fc-toolbar-title {
-    font-size: 2.3em;
-    /*margin: 0px;*/
-    font-weight: bold;
+@media screen and (min-width:501px){
+    body {
+        /*margin: 40px 10px;*/
+        padding: 0;
+        font-family: Arial, Helvetica Neue, Helvetica, sans-serif;
+        font-size: 16px;
+        height:100%;
+    }
+    .fc-toolbar-title{
+        font-size: 28px !important;
+        font-weight: bold;
+    }
 }
+/*@media screen and (max-height:500px){*/
+/*    body {*/
+/*        !*margin: 40px 10px;*!*/
+/*        padding: 0;*/
+/*        font-family: Arial, Helvetica Neue, Helvetica, sans-serif;*/
+/*        font-size: 11px;*/
+/*        height:100%;*/
+/*    }*/
+/*   */
+/*}*/
+
+
+/*.fc .fc-toolbar-title {*/
+/*    font-size: 2.3em;*/
+/*    !*margin: 0px;*!*/
+/*    font-weight: bold;*/
+/*}*/
 
 .fc-event {
     border: none !important; /* 일정의 테두리 제거 */
@@ -192,30 +338,98 @@ li {
     /* 일정 제목을 굵게 설정합니다 */
 }
 
-.fc .fc-button-primary {
+.fc .fc-button-primary:hover {
     background-color: #f8f9fa;
-    /* border-color: rgba(255, 255, 255, 0.15); */
-    color: #495057;
-    /* font-weight: bold; */
+    /*border: none;*/
+    transform: scale(1.1);
+    color: #4FD1C5;
+    border-color: #4FD1C5;
 }
 
-.dropdown-menu {
-    display: none; /* 기본적으로 숨김 */
-    position: absolute;
-    background-color: #f1f1f1;
-    min-width: 160px;
-    box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2);
-    z-index: 1;
+.fc .fc-button-primary:disabled {
+    background-color: #4FD1C5;
+    border-color: #4FD1C5;
+    color: #ffffff;
 }
 
-.show {
-    display: block; /* 보이게 함 */
+.fc-header-toolbar .fc-button{
+    border-color: lightgrey;
+    background-color: #ffffff;
+    color: #414141;
 }
+
+
+/*.fc-daygrid-event-dot {*/
+/*    display: none;*/
+/*}*/
+
+
+/*.dropdown-menu {*/
+/*    display: none; !* 기본적으로 숨김 *!*/
+/*    position: absolute;*/
+/*    background-color: #f1f1f1;*/
+/*    min-width: 160px;*/
+/*    box-shadow: 0 8px 16px 0 rgba(0,0,0,0.2);*/
+/*    z-index: 1;*/
+/*}*/
+
+/*.show {*/
+/*    display: block; !* 보이게 함 *!*/
+/*}*/
 
 /* 추가함! */
 /* 드롭다운(전체,개인,그룹) */
-.dropdown-toggle {
-    width: 8%;
-    min-width: 70px;
-    margin-bottom: 3px;
+/*.dropdown-toggle {*/
+/*    width: 8%;*/
+/*    min-width: 70px;*/
+/*    margin-bottom: 3px;*/
+/*}*/
+
+.fc .fc-highlight {
+    /*background: var(--fc-highlight-color);*/
+    border-color: #4FD1C5;
+    border: 3px;
+}
+
+.dropdown-menu {
+    position: absolute;
+    /*margin-top: 20px;*/
+    background-color: white;
+    padding: 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    display: none;
+
+    /*position: absolute;*/
+    /*top: 100%;*/
+    /*left: 0;*/
+    /*z-index: 5000;*/
+    /*display: none;*/
+    /*float: left;*/
+    /*min-width: 10rem;*/
+    /*padding: .5rem 0;*/
+    /*margin: .125rem 0 0;*/
+    /*font-size: 1rem;*/
+    /*color: #212529;*/
+    /*text-align: left;*/
+    /*list-style: none;*/
+    /*background-color: #fff;*/
+    /*background-clip: padding-box;*/
+    /*border: 1px solid rgba(0, 0, 0, .15);*/
+    /*border-radius: .25rem;*/
+}
+
+.dropdown-item {
+    display: block;
+    padding: 5px 10px;
+    text-decoration: none;
+    color: #333;
+}
+
+.dropdown-item:hover {
+    background-color: #f0f0f0;
+}
+
+.show {
+    display: block;
 }

--- a/src/main/resources/static/css/inc/alarm.css
+++ b/src/main/resources/static/css/inc/alarm.css
@@ -9,6 +9,7 @@
     background-color: #4FD1C5;
     color: #ffffff;
     border-radius: .5rem;
+    cursor: pointer;
 }
 
 
@@ -53,6 +54,7 @@
     margin: 0 20px;
     font-size: large;
     font-weight: bold;
+    border-bottom: 1px solid;
 
 }
 
@@ -103,7 +105,8 @@
     width: 300px;
     /*height: 200px;*/
     font-size: small;
-    margin-bottom: 15px;
+    margin-bottom: 5px;
+    margin-top: 10px;
     border-radius: 5px;
     background-color: #ffffff;
     /* z-index: 10; */

--- a/src/main/resources/static/css/inc/alarm.css
+++ b/src/main/resources/static/css/inc/alarm.css
@@ -1,0 +1,197 @@
+
+#alarmIcon {
+    position: fixed;
+    top: 1.2%;
+    right: 1.2%;
+    z-index: 9999;
+    font-size: 1.6rem;
+    padding: .1rem .55rem;
+    background-color: #4FD1C5;
+    color: #ffffff;
+    border-radius: .5rem;
+}
+
+
+#alarmIcon.active-icon {
+    background-color: #ffffff;
+    color: #4FD1C5;
+    border-radius: .1rem;
+    z-index: 9999;
+
+}
+
+.overlay-container {
+    display: none;
+    position: fixed;
+    height: 100vh;
+    top: 1.2%;
+    right: 1.2%;
+    width: 340px;
+    z-index: 50; /* 다른 요소 위에 표시하기 위해 z-index를 설정합니다. */
+    border-radius: 10px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1); /* 가로, 세로, 흐림 정도, 색상 */;
+    /* border-radius: .3rem; */
+     background-color: #ffffff;
+    /* border-color: #4FD1C5; */
+    /* animation: fade-in 450ms; */
+    /* top: calc(100% + 10px); */
+    /* height: 30%; */
+    /* height: calc(100vh - 100px); */
+}
+
+
+
+.msg-overlay-bubble {
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    width: 310px;
+    /*box-shadow: left only;*/
+}
+
+.msg-overlay-bubble-header {
+    margin: 0 20px;
+    font-size: large;
+    font-weight: bold;
+
+}
+
+/* 오버레이를 표시합니다. */
+.overlay-container.show-overlay {
+    display: block;
+    width: 310px;
+}
+
+
+.msg-overlay-bubble-list {
+    flex: 80%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    height: 90%;
+    background-color: #ffffff;
+    overflow-y: scroll; /* 세로 스크롤 사용 */
+}
+
+/* 스크롤바 전체 영역 */
+::-webkit-scrollbar {
+    width: 10px;  /* 세로축 스크롤바 폭 너비 */
+    height: 20px;  /* 가로축 스크롤바 폭 너비 */
+}
+
+/* 스크롤바 막대 */
+::-webkit-scrollbar-thumb {
+    background: rgba(83, 166, 249, 0.75);
+    border-radius: 2em;
+    height: 15px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background-color:#eeeef1;
+}
+
+/* 스크롤이 움직이는 뒷 배경 */
+::-webkit-scrollbar-track {
+    background: rgba(220, 20, 60, .1);  /*스크롤바 뒷 배경 색상*/
+}
+
+/*일정상세카드*/
+.card-outer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: 300px;
+    /*height: 200px;*/
+    font-size: small;
+    margin-bottom: 15px;
+    border-radius: 5px;
+    background-color: #ffffff;
+    /* z-index: 10; */
+    /* padding: 2px, 2px, 2px, 2px; */
+    /* padding-left: 5px; */
+    /* border-style: solid ; */
+    /* border-color: rgb(28, 248, 174); */
+    /* background-color: #ffffff63; */
+    /* left: 10px; */
+}
+
+.card-name {
+    width: 90%;
+    height: 15%;
+    margin: 5px 10px;
+    font-weight: bold;
+}
+
+.card-main {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-content: space-between;
+    background-color: #ffffffe2;
+    width: 280px;
+    height: 130px;
+    border-radius: 5px;
+    margin-bottom: 10px;
+    box-shadow: 0px 5px 10px rgba(0, 0, 0, 0.2);
+    font-weight: bold;
+}
+
+.card-main-1 {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    margin: 0 10px;
+    height: 30%;
+}
+
+.card-main-2 {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    margin: 0 10px;
+    height: 30%;
+}
+
+.card-main-3 {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    margin: 0 10px;
+    height: 30%;
+}
+
+h3 {
+    font-size: 18px;
+}
+
+/* .category1 {
+    background-color: rgb(71, 147, 175);
+    border-radius: 5px;
+    font-weight: bold;
+    color: #071241;
+}
+
+.category2 {
+    background-color: rgb(255, 196, 112);
+    border-radius: 5px;
+    font-weight: bold;
+    color: #071241;
+
+}
+
+.category3 {
+    background-color: rgb(221, 87, 70);
+    border-radius: 5px;
+    font-weight: bold;
+    color: #071241;
+}
+
+.category4 {
+    background-color: rgb(139, 50, 44);
+    border-radius: 5px;
+    font-weight: bold;
+    color: #071241;
+} */

--- a/src/main/resources/static/js/calendar.js
+++ b/src/main/resources/static/js/calendar.js
@@ -34,7 +34,7 @@ $(document).ready(function() {
             console.error("Error:", error); // 에러처리
         }
     });
-
+// console.log(data)
 
     // 캘린더에 일정 표시하는 함수
     function displayEventsOnCalendar(data) {
@@ -49,9 +49,9 @@ $(document).ready(function() {
             navLinks: false,  //  요일이랑 날짜 클릭 시 일이나 주단위 보여주는 화면으로 넘어감
             select: function (info) {
                 // 클릭한 날짜 정보를 콘솔에 출력
-                console.log('Clicked date:', info.start);
+                // console.log('Clicked date:', info.start);
                 // -> 확인용 코드
-                console.log(info);
+                // console.log(info);
                 // 클릭한 날짜에 해당하는 일정 가져오기
                 let selectedDate = info.start;
                 let selectedEvents = getEventsForDate(selectedDate);
@@ -85,39 +85,73 @@ $(document).ready(function() {
                         }
 
                         // 일정 카테고리에 따라 일정 필터링하는 함수
-                        //
-
                         function filterEventsByCategory(category) {
                             calendar.getEvents().forEach(function (event) {
-                                console.log(data.isGroup)
                                 if (category === 'all') {
-                                    event.setProp('display', 'block'); // 모든 일정 보이기
-                                    console.log(event)
+                                    // 전체 카테고리 선택 시 모든 일정을 표시합니다.
+                                    event.setProp('display', 'block');
                                 } else {
-                                    if (data.extendedProps.isGroup == 'personal') {
-                                        // console.log(data.isGroup)
-                                        event.setProp('display', 'none'); // 해당 카테고리가 아닌 일정 숨기기
-                                    } else if (event.extendedProps.isGroup == 'group') {
-                                        event.setProp('display', 'block'); // 해당 카테고리의 일정 보이기
+                                    // 개인, 그룹 카테고리 선택 시 해당 카테고리에 맞는 일정만 표시합니다.
+                                    let isGroup = event.extendedProps.isGroup;
+                                    console.log(isGroup)
+                                    if ((category === 'personal' && !isGroup) || (category === 'group' && isGroup)) {
+                                        event.setProp('display', 'block');
+                                    } else {
+                                        event.setProp('display', 'none');
                                     }
                                 }
-
                             });
                         }
 
 
                         // drop down 버튼 클릭 시 이벤트 처리
-                        $('#customDropdownMenu .dropdown-item').click(function (e) {
-                            e.preventDefault();
-                            let category = $(this).data('category');
-                            $('.btn-secondary').text($(this).text()); // drop down 버튼 텍스트 변경
-                            // console.log(category)
-                            hideDropdownMenu(); // 드롭다운 메뉴 숨기기
-                            filterEventsByCategory(category); // 선택한 카테고리에 따라 일정 필터링
+                        // $('#customDropdownMenu .dropdown-item').click(function (e) {
+                        //     e.preventDefault();
+                        //     let category = $(this).data('category');
+                        //     $('.customDropdownMenu').text($(this).text()); // drop down 버튼 텍스트 변경
+                        //     // console.log($('.btn-secondary').text($(this).text()))
+                        //     console.log($(this).text())
+                        //     hideDropdownMenu(); // 드롭다운 메뉴 숨기기
+                        //     filterEventsByCategory(category); // 선택한 카테고리에 따라 일정 필터링
+                        // });
+
+                        // $('#customDropdownMenu .dropdown-item').click(function(e) {
+                        //     e.preventDefault();
+                        //     // 클릭한 항목의 텍스트를 가져와서 변수에 저장
+                        //     let newText = $(this).text();
+                        //     // customDropdownMenu 클래스를 가진 요소의 텍스트를 변경
+                        //     $('customDropdownMenu').text(newText);
+                        //     console.log($(this).text())
+                        //     // 드롭다운 메뉴를 숨김
+                        //     $('#customDropdownMenu').removeClass('show');
+                        //     // 선택한 카테고리에 따라 일정 필터링
+                        //     filterEventsByCategory($(this).data('category'));
+                        // });
+
+                        $(document).ready(function() {
+                            // 리스트 요소 클릭 시 드롭다운 버튼의 텍스트 변경
+                            $('#customDropdownMenu .dropdown-item').click(function (e) {
+                                e.preventDefault();
+                                let newText = $(this).text(); // 클릭된 리스트 요소의 텍스트 가져오기
+                                $('.fc-customDropdownMenu-button').text(newText); // 드롭다운 버튼의 텍스트 변경
+                                $('#customDropdownMenu').removeClass('show');
+                                filterEventsByCategory($(this).data('category'));
+                            });
                         });
+
+                        // customDropdownMenu 위치 조정
+                        $('#customDropdownMenu').css({
+                            'position': 'absolute',
+                            'top': $('.fc-customDropdownMenu-button').offset().top + $('.fc-customDropdownMenu-button').outerHeight()+5,
+                            'left': $('.fc-customDropdownMenu-button').offset().left - $('#customDropdownMenu').outerWidth() + $('.fc-customDropdownMenu-button').outerWidth()+5
+                        });
+
+
                     }
+
                 }
             },
+
 
             initialDate: today, // 달력 처음 로드될 때 표시되는 날짜, default 는 현재 날짜
             editable: false,
@@ -127,6 +161,7 @@ $(document).ready(function() {
                 return {
                     title: event.name,
                     start: event.startDate,
+                    // propA: event.description,  -> 일정 상세는 데이터 안 받아오네...
                     backgroundColor: event.color,
                     textColor: "#ffffff"
                 };
@@ -193,7 +228,7 @@ $(document).ready(function() {
                     'flex': '1'
                 });
                 let titleSpan = $('<span>').text(event.name).addClass('event-title').css('margin-bottom', '5px');
-                let detailSpan = $('<span>').text(event.propA).addClass('event-detail');
+                let detailSpan = $('<span>').text(event.description).addClass('event-detail');
                 titleAndDetail.append(titleSpan, detailSpan);
                 li.append(titleAndDetail);
 

--- a/src/main/resources/static/js/calendar.js
+++ b/src/main/resources/static/js/calendar.js
@@ -1,3 +1,4 @@
+
 $(document).ready(function() {
     // 오늘 날짜 가져오기
     let today = new Date();
@@ -10,153 +11,118 @@ $(document).ready(function() {
     // tit_date 요소에 오늘 날짜 표시
     $('.tit_date').text(today);
 
-    // 캘린더 div 참조
-    let calendarEl = document.getElementById('calendar');
 
-    let events = [
-        {
-            title : ' tomcat 뿌시기',
-            start: '2024-05-01T08:30:00',
-            allDay: false,
-            category: 'category1', // 카테고리 정보 추가
-            propA: '일정상세정보...'
+    // ajax 통해 서버에서 일정 데이터 가져오기
+    $.ajax({
+        type: 'GET',
+        url: 'api/schedule/calendar',
+        dataType: 'json',
+        success: function(response) {
+            // 일정 가져오는데 성공하면 캘린더에 표시
+            displayEventsOnCalendar(response.events);
         },
-        {
-            title : ' spring 뿌시기',
-            start: '2024-05-12T08:30:00',
-            end: '2024-05-14T16:00:00',
-            category: 'category2',
-            propA: '일정상세정보...'
-        },
-        {
-            title : ' jquery 뿌시기',
-            start: '2024-05-16T16:00:00',
-            allDay: false,
-            category: 'category3',
-            propA: '일정상세정보...'
-        },
-        // 카테고리별로 추가적인 일정 정보를 배열에 추가 가능
-        {
-            title : ' sql developer 뿌시기',
-            start: '2024-05-16T17:35:00',
-            allDay: false,
-            category: 'category2',
-            propA: '일정상세정보...'
-        },
-        {
-            title : ' 맛집 탐방',
-            start: '2024-05-21T11:45:00',
-            allDay: false,
-            category: 'category1',
-            propA: '일정상세정보...'
-        },
-        {
-            title : ' 공원 나들이',
-            start: '2024-05-16T11:45:00',
-            allDay: false,
-            category: 'category1',
-            propA: '일정상세정보...'
-        },
-        {
-            title : ' 한강 나들이',
-            start: '2024-05-21T08:45:00',
-            allDay: false,
-            category: 'category2',
-            propA: '일정상세정보...'
-        },
-        {
-            title: ' 밥약',
-            start: '2024-05-16T18:45:00',
-            allDay: false,
-            category: 'category2',
-            propA: '일정상세정보...'
+        error: function(xhr, status, error) {
+            console.error("Error:", error); // 에러처리
         }
-    ]
-
-    let calendar = new FullCalendar.Calendar(calendarEl, {
-        timeZone: 'UTC',
-        themeSystem: 'bootstrap5',
-        initialView: 'dayGridMonth',
-        // contentHeight: 600,
-        editable: true,  //  드래그해서 수정 가능한지, 길게 확장도 가능
-        selectable: true,
-        navLinks: true,  //  요일이랑 날짜 클릭 시 일이나 주단위 보여주는 화면으로 넘어감
-        select: function(info) {
-            // 클릭한 날짜 정보를 콘솔에 출력
-            // console.log('Clicked date:', info.start);
-            // -> 확인용 코드
-            console.log(info);
-            // 클릭한 날짜에 해당하는 일정 가져오기
-            let selectedDate = info.start;
-            let selectedEvents = getEventsForDate(selectedDate);
-
-            // console.log(selectedEvents)
-            // 가져온 일정을 리스트 형식으로 보여주기
-            showEventsList(selectedEvents);
-
-            // 클릭한 날짜를 tit_date에 표시
-            let clickedDate = selectedDate.toISOString().slice(0, 10); // YYYY-MM-DD 형식으로 변환
-            $('.tit_date').text(clickedDate);
-        },
-
-        headerToolbar: {
-            left: 'prev,next',
-            center: 'title',
-            right: 'today'
-        },
-
-        initialDate: today, // 달력 처음 로드될 때 표시되는 날짜, default 는 현재 날짜
-        editable: false,
-        dayMaxEvents: true, // +more 표시 전 최대 이벤트 갯수, true는 셀 높이에 의해 결정
-        eventLimit: true,
-        events: events.map(function(event) {
-            return {
-                title: event.title,
-                start: event.start,
-                backgroundColor: getCategoryColor(event.category),
-                textColor: "#ffffff"
-            };
-        }),
     });
 
-    calendar.render();
+    // 캘린더에 일정 표시하는 함수
+    function displayEventsOnCalendar(events) {
+        let calendarEl = document.getElementById('calendar');
+        let calendar = new FullCalendar.Calendar(calendarEl, {
+            timeZone: 'UTC',
+            themeSystem: 'bootstrap5',
+            initialView: 'dayGridMonth',
+            // contentHeight: 600,
+            editable: true,  //  드래그해서 수정 가능한지, 길게 확장도 가능
+            selectable: true,
+            navLinks: false,  //  요일이랑 날짜 클릭 시 일이나 주단위 보여주는 화면으로 넘어감
+            select: function (info) {
+                // 클릭한 날짜 정보를 콘솔에 출력
+                console.log('Clicked date:', info.start);
+                // -> 확인용 코드
+                console.log(info);
+                // 클릭한 날짜에 해당하는 일정 가져오기
+                let selectedDate = info.start;
+                let selectedEvents = getEventsForDate(selectedDate);
 
-    $('#myDropdownButton').click(function() {
-        $('#customDropdownMenu').toggleClass('show');
-    });
+                // console.log(selectedEvents)
+                // 가져온 일정을 리스트 형식으로 보여주기
+                showEventsList(selectedEvents);
 
-    $('.dropdown-item').click(function() {
-        let text = $(this).text();
-        console.log(text + ' clicked');
-        hideDropdownMenu();
-        $('#myDropdownButton').text(text);
-    });
+                // 클릭한 날짜를 tit_date에 표시
+                let clickedDate = selectedDate.toISOString().slice(0, 10); // YYYY-MM-DD 형식으로 변환
+                $('.tit_date').text(clickedDate);
+            },
 
-    function hideDropdownMenu() {
-        $('#customDropdownMenu').removeClass('show');
+            headerToolbar: {
+                start: 'today prev,next',
+                center: 'title',
+                right: 'customDropdownMenu'
+            },
+
+            customButtons: {
+                customDropdownMenu: {
+                    text: '전체',
+                    click: function () {
+                        $('#customDropdownMenu').toggleClass('show');
+                        // $('#customDropdownMenu').empty(); // 이전 내용 지우기
+
+
+                        // drop down 메뉴 숨기는 함수
+                        function hideDropdownMenu() {
+                            $('#customDropdownMenu').removeClass('show');
+                        }
+
+                        // 일정 카테고리에 따라 일정 필터링하는 함수
+                        function filterEventsByCategory(category) {
+                            calendar.getEvents().forEach(function (event) {
+                                if (category === 'all') {
+                                    event.setProp('display', 'block'); // 모든 일정 보이기
+                                } else {
+                                    if (event.extendedProps.isGroup !== category) {
+                                        event.setProp('display', 'none'); // 해당 카테고리가 아닌 일정 숨기기
+                                    } else {
+                                        event.setProp('display', 'block'); // 해당 카테고리의 일정 보이기
+                                    }
+                                }
+                            });
+                        }
+
+                        // drop down 버튼 클릭 시 이벤트 처리
+                        $('#customDropdownMenu .dropdown-item').click(function (e) {
+                            e.preventDefault();
+                            let category = $(this).data('category');
+                            $('.btn-secondary').text($(this).text()); // drop down 버튼 텍스트 변경
+                            console.log(category)
+                            hideDropdownMenu(); // 드롭다운 메뉴 숨기기
+                            filterEventsByCategory(category); // 선택한 카테고리에 따라 일정 필터링
+                        });
+                    }
+                }
+            },
+
+            initialDate: today, // 달력 처음 로드될 때 표시되는 날짜, default 는 현재 날짜
+            editable: false,
+            dayMaxEvents: true, // +more 표시 전 최대 이벤트 갯수, true는 셀 높이에 의해 결정
+            eventLimit: true,
+            events: events.map(function (event) {
+                return {
+                    title: event.name,
+                    start: event.startDate,
+                    backgroundColor: event.color,
+                    textColor: "#ffffff"
+                };
+            }),
+
+        });
+
+        calendar.render();
     }
-
-
-
-    // dropdown 버튼 클릭 시 메뉴 토글
-    $('#dropdownMenuButton1').click(function() {
-        $('#customDropdownMenu').toggleClass('show');
-    });
-
-    // 각 dropdown 아이템 클릭 시 처리
-    $('.dropdown-item').click(function() {
-        var text = $(this).text();
-        console.log(text + ' clicked');
-        hideDropdownMenu();
-        // dropdown button의 텍스트 변경
-        $('#customDropdownButton').text(text);
-    });
-
 
     // 클릭한 날짜에 해당하는 일정을 가져오는 함수
     function getEventsForDate(date) {
         // 클릭한 날짜에 해당하는 일정 데이터를 필터링하여 반환
-
         return events.filter(event => new Date(event.start).toDateString() === date.toDateString());
     }
 
@@ -168,71 +134,241 @@ $(document).ready(function() {
         // 기존에 있는 일정 목록을 초기화
         sidebar.empty();
 
+        // 가져온 일정 데이터를 시작 시간을 기준으로 정렬
+        events.sort((a, b) => {
+            return new Date(a.start) - new Date(b.start);
+        });
+
         // 가져온 일정 데이터를 리스트 형식으로 추가
-        let ul = $('<ul>').addClass('events-list');
+        let ul = $('<ul>').addClass('events-list').css({
+            'display': 'flex',
+            'flex-direction': 'column'
+        });
+
 
         events.forEach(event => {
-            let li = $('<li>');
+            let li = $('<li>').addClass('event-item');
 
-
-            let dateTimeArray = event.start.split('T');
+            // 시간 정보 추가
+            let dateTimeArray = event.start.split(' ');
             let date = dateTimeArray[0]; // 날짜 부분
-            let full_time = dateTimeArray[1]; // 시간 부분  00:00:00
-
-
+            let full_time = dateTimeArray[1]; // 시간 부분  00:00
             let TimeArray = full_time.split(':');
             let hour = TimeArray[0];
             let min = TimeArray[1];
-
-
-            li.html(`${hour}:${min} ${event.title} <br> ${event.propA}`);
-
+            let timeSpan = $('<span>').text(`${hour}:${min}`).addClass('event-time').css('margin-right', '3px');
+            li.append(timeSpan);
 
             // 일정에 해당하는 카테고리의 색상 적용
-            // li.css('background-color', getCategoryColor(event.category));
-            li.css('border-left', '4px solid ' + getCategoryColor(event.category));
-            ul.css('padding', '0 0 0 4px ');
+            let colorBar = $('<span>').addClass('color-bar').css({
+                'background-color': event.color,
+                'display': 'inline-block',
+                'width': '4px',
+                'margin-right': '5px',
+                'margin-left': '5px'
+            });
+            li.append(colorBar);
 
-            console.log(li)
-            $(ul).append(li);
+            // 제목과 상세 정보 추가
+            let titleAndDetail = $('<div>').addClass('title-and-detail').css({
+                'display': 'flex',
+                'flex-direction': 'column',
+                'flex': '1'
+            });
+            let titleSpan = $('<span>').text(event.name).addClass('event-title').css('margin-bottom', '5px');
+            let detailSpan = $('<span>').text(event.propA).addClass('event-detail');
+            titleAndDetail.append(titleSpan, detailSpan);
+            li.append(titleAndDetail);
 
             // 클릭 이벤트 추가
-            li.on('click', function() {
+            li.on('click', function () {
                 // 클릭한 날짜에 해당하는 캘린더 이벤트 선택
                 calendar.select(event.start);
-                // calendar.select(event.end);
-
             });
+
+            ul.append(li);
         });
 
         // 리스트를 우측 사이드바에 추가
         sidebar.append(ul);
     }
-
-    // 이벤트 시작일을 포맷하는 함수
-    function formatDateTime(date) {
-        let hours = date.getHours().toString().padStart(2, '0'); // 시간
-        let minutes = date.getMinutes().toString().padStart(2, '0'); // 분
-        return hours + ':' + minutes;
-    }
-
-    // dropdown 메뉴 숨기는 함수
-    function hideDropdownMenu() {
-        $('#customDropdownMenu').removeClass('show');
-    }
-
-    // 각 카테고리에 대한 색상 반환
-    function getCategoryColor(category) {
-        switch (category) {
-            case 'category1':
-                return "rgb(71, 147, 175)";
-            case 'category2':
-                return "rgb(255, 196, 112)"
-            case 'category3':
-                return "rgb(221, 87, 70)"
-            case 'category4':
-                return "rgb(139, 50, 44)"
-        }
-    }
-
 });
+
+    // // 캘린더 div 참조
+    // let calendarEl = document.getElementById('calendar');
+    //
+    //
+    // let calendar = new FullCalendar.Calendar(calendarEl, {
+    //     timeZone: 'UTC',
+    //     themeSystem: 'bootstrap5',
+    //     initialView: 'dayGridMonth',
+    //     // contentHeight: 600,
+    //     editable: true,  //  드래그해서 수정 가능한지, 길게 확장도 가능
+    //     selectable: true,
+    //     navLinks: false,  //  요일이랑 날짜 클릭 시 일이나 주단위 보여주는 화면으로 넘어감
+    //     select: function (info) {
+    //         // 클릭한 날짜 정보를 콘솔에 출력
+    //         console.log('Clicked date:', info.start);
+    //         // -> 확인용 코드
+    //         console.log(info);
+    //         // 클릭한 날짜에 해당하는 일정 가져오기
+    //         let selectedDate = info.start;
+    //         let selectedEvents = getEventsForDate(selectedDate);
+    //
+    //         // console.log(selectedEvents)
+    //         // 가져온 일정을 리스트 형식으로 보여주기
+    //         showEventsList(selectedEvents);
+    //
+    //         // 클릭한 날짜를 tit_date에 표시
+    //         let clickedDate = selectedDate.toISOString().slice(0, 10); // YYYY-MM-DD 형식으로 변환
+    //         $('.tit_date').text(clickedDate);
+    //     },
+    //
+    //     headerToolbar: {
+    //         start: 'today prev,next',
+    //         center: 'title',
+    //         right: 'customDropdownMenu'
+    //     },
+    //
+    //     customButtons: {
+    //         customDropdownMenu: {
+    //             text: '전체',
+    //             click: function () {
+    //                 $('#customDropdownMenu').toggleClass('show');
+    //                 // $('#customDropdownMenu').empty(); // 이전 내용 지우기
+    //
+    //
+    //                 // drop down 메뉴 숨기는 함수
+    //                 function hideDropdownMenu() {
+    //                     $('#customDropdownMenu').removeClass('show');
+    //                 }
+    //
+    //                 // 일정 카테고리에 따라 일정 필터링하는 함수
+    //                 function filterEventsByCategory(category) {
+    //                     calendar.getEvents().forEach(function (event) {
+    //                         if (category === 'all') {
+    //                             event.setProp('display', 'block'); // 모든 일정 보이기
+    //                         } else {
+    //                             if (event.extendedProps.isGroup !== category) {
+    //                                 event.setProp('display', 'none'); // 해당 카테고리가 아닌 일정 숨기기
+    //                             } else {
+    //                                 event.setProp('display', 'block'); // 해당 카테고리의 일정 보이기
+    //                             }
+    //                         }
+    //                     });
+    //                 }
+    //
+    //                 // drop down 버튼 클릭 시 이벤트 처리
+    //                 $('#customDropdownMenu .dropdown-item').click(function (e) {
+    //                     e.preventDefault();
+    //                     let category = $(this).data('category');
+    //                     $('.btn-secondary').text($(this).text()); // drop down 버튼 텍스트 변경
+    //                     console.log(category)
+    //                     hideDropdownMenu(); // 드롭다운 메뉴 숨기기
+    //                     filterEventsByCategory(category); // 선택한 카테고리에 따라 일정 필터링
+    //                 });
+    //             }
+    //         }
+    //     },
+    //
+    //     initialDate: today, // 달력 처음 로드될 때 표시되는 날짜, default 는 현재 날짜
+    //     editable: false,
+    //     dayMaxEvents: true, // +more 표시 전 최대 이벤트 갯수, true는 셀 높이에 의해 결정
+    //     eventLimit: true,
+    //     // events: events.map(function (event) {
+    //     //     return {
+    //     //         title: event.name,
+    //     //         start: event.startDate,
+    //     //         backgroundColor: event.color,
+    //     //         textColor: "#ffffff"
+    //     //     };
+    //     // }),
+    //
+    // });
+    //
+    // calendar.render();
+    //
+    //
+    // // 클릭한 날짜에 해당하는 일정을 가져오는 함수
+    // function getEventsForDate(date) {
+    //     // 클릭한 날짜에 해당하는 일정 데이터를 필터링하여 반환
+    //
+    //     return events.filter(event => new Date(event.start).toDateString() === date.toDateString());
+    // }
+    //
+    // // 클릭한 날짜에 해당하는 일정을 리스트 형식으로 보여주는 함수
+    // function showEventsList(events) {
+    //     // 우측 사이드바에 있는 일정 목록을 참조
+    //     let sidebar = $('.area_agenda_info');
+    //
+    //     // 기존에 있는 일정 목록을 초기화
+    //     sidebar.empty();
+    //
+    //     // 가져온 일정 데이터를 시작 시간을 기준으로 정렬
+    //     events.sort((a, b) => {
+    //         return new Date(a.start) - new Date(b.start);
+    //     });
+    //
+    //     // 가져온 일정 데이터를 리스트 형식으로 추가
+    //     let ul = $('<ul>').addClass('events-list').css({
+    //         'display': 'flex',
+    //         'flex-direction': 'column'
+    //     });
+    //
+    //
+    //     events.forEach(event => {
+    //         let li = $('<li>').addClass('event-item');
+    //
+    //         // 시간 정보 추가
+    //         let dateTimeArray = event.start.split(' ');
+    //         let date = dateTimeArray[0]; // 날짜 부분
+    //         let full_time = dateTimeArray[1]; // 시간 부분  00:00
+    //         let TimeArray = full_time.split(':');
+    //         let hour = TimeArray[0];
+    //         let min = TimeArray[1];
+    //         let timeSpan = $('<span>').text(`${hour}:${min}`).addClass('event-time').css('margin-right', '3px');
+    //         li.append(timeSpan);
+    //
+    //         // 일정에 해당하는 카테고리의 색상 적용
+    //
+    //         let colorBar = $('<span>').addClass('color-bar').css({
+    //             'background-color': event.color,
+    //             'display': 'inline-block',
+    //             'width': '4px',
+    //             'margin-right': '5px',
+    //             'margin-left': '5px'
+    //         });
+    //         li.append(colorBar);
+    //
+    //         // 제목과 상세 정보 추가
+    //         let titleAndDetail = $('<div>').addClass('title-and-detail').css({
+    //             'display': 'flex',
+    //             'flex-direction': 'column',
+    //             'flex': '1'
+    //         });
+    //         let titleSpan = $('<span>').text(event.name).addClass('event-title').css('margin-bottom', '5px');
+    //         let detailSpan = $('<span>').text(event.propA).addClass('event-detail');
+    //         titleAndDetail.append(titleSpan, detailSpan);
+    //         li.append(titleAndDetail);
+    //
+    //         // 클릭 이벤트 추가
+    //         li.on('click', function () {
+    //             // 클릭한 날짜에 해당하는 캘린더 이벤트 선택
+    //             calendar.select(event.star);
+    //         });
+    //
+    //         ul.append(li);
+    //     });
+    //
+    //     // 리스트를 우측 사이드바에 추가
+    //     sidebar.append(ul);
+    // }
+    //
+    // // 이벤트 시작일을 포맷하는 함수
+    // function formatDateTime(date) {
+    //     let hours = date.getHours().toString().padStart(2, '0'); // 시간
+    //     let minutes = date.getMinutes().toString().padStart(2, '0'); // 분
+    //     return hours + ':' + minutes;
+    // }
+// })
+

--- a/src/main/resources/static/js/calendar.js
+++ b/src/main/resources/static/js/calendar.js
@@ -5,8 +5,12 @@ $(document).ready(function() {
     let dd = String(today.getDate()).padStart(2, '0');
     let mm = String(today.getMonth() + 1).padStart(2, '0'); // 0부터 시작하기 때문에 1을 더해줍니다.
     let yyyy = today.getFullYear();
-
+    console.log(today) // Mon May 13 2024 10:52:02 GMT+0900 (한국 표준시)
+    console.log(dd)    // 13
+    console.log(mm)    // 05
+    console.log(yyyy)  // 2024
     today = yyyy + '-' + mm + '-' + dd;
+    console.log(today)  // 2024-05-13
 
     // tit_date 요소에 오늘 날짜 표시
     $('.tit_date').text(today);
@@ -15,19 +19,25 @@ $(document).ready(function() {
     // ajax 통해 서버에서 일정 데이터 가져오기
     $.ajax({
         type: 'GET',
-        url: 'api/schedule/calendar',
+        url: '/api/schedule/calendar',
         dataType: 'json',
+        data: {
+            year: yyyy,
+            month: mm
+        },
         success: function(response) {
+            console.log(response.data);
             // 일정 가져오는데 성공하면 캘린더에 표시
-            displayEventsOnCalendar(response.events);
+            displayEventsOnCalendar(response.data);
         },
         error: function(xhr, status, error) {
             console.error("Error:", error); // 에러처리
         }
     });
 
+
     // 캘린더에 일정 표시하는 함수
-    function displayEventsOnCalendar(events) {
+    function displayEventsOnCalendar(data) {
         let calendarEl = document.getElementById('calendar');
         let calendar = new FullCalendar.Calendar(calendarEl, {
             timeZone: 'UTC',
@@ -75,26 +85,33 @@ $(document).ready(function() {
                         }
 
                         // 일정 카테고리에 따라 일정 필터링하는 함수
+                        //
+
                         function filterEventsByCategory(category) {
                             calendar.getEvents().forEach(function (event) {
+                                console.log(data.isGroup)
                                 if (category === 'all') {
                                     event.setProp('display', 'block'); // 모든 일정 보이기
+                                    console.log(event)
                                 } else {
-                                    if (event.extendedProps.isGroup !== category) {
+                                    if (data.extendedProps.isGroup == 'personal') {
+                                        // console.log(data.isGroup)
                                         event.setProp('display', 'none'); // 해당 카테고리가 아닌 일정 숨기기
-                                    } else {
+                                    } else if (event.extendedProps.isGroup == 'group') {
                                         event.setProp('display', 'block'); // 해당 카테고리의 일정 보이기
                                     }
                                 }
+
                             });
                         }
+
 
                         // drop down 버튼 클릭 시 이벤트 처리
                         $('#customDropdownMenu .dropdown-item').click(function (e) {
                             e.preventDefault();
                             let category = $(this).data('category');
                             $('.btn-secondary').text($(this).text()); // drop down 버튼 텍스트 변경
-                            console.log(category)
+                            // console.log(category)
                             hideDropdownMenu(); // 드롭다운 메뉴 숨기기
                             filterEventsByCategory(category); // 선택한 카테고리에 따라 일정 필터링
                         });
@@ -106,7 +123,7 @@ $(document).ready(function() {
             editable: false,
             dayMaxEvents: true, // +more 표시 전 최대 이벤트 갯수, true는 셀 높이에 의해 결정
             eventLimit: true,
-            events: events.map(function (event) {
+            events: data.map(function (event) {
                 return {
                     title: event.name,
                     start: event.startDate,
@@ -118,257 +135,85 @@ $(document).ready(function() {
         });
 
         calendar.render();
-    }
 
-    // 클릭한 날짜에 해당하는 일정을 가져오는 함수
-    function getEventsForDate(date) {
-        // 클릭한 날짜에 해당하는 일정 데이터를 필터링하여 반환
-        return events.filter(event => new Date(event.start).toDateString() === date.toDateString());
-    }
+        // 클릭한 날짜에 해당하는 일정을 가져오는 함수
+        function getEventsForDate(date) {
+            // 클릭한 날짜에 해당하는 일정 데이터를 필터링하여 반환
 
-    // 클릭한 날짜에 해당하는 일정을 리스트 형식으로 보여주는 함수
-    function showEventsList(events) {
-        // 우측 사이드바에 있는 일정 목록을 참조
-        let sidebar = $('.area_agenda_info');
+            return data.filter(event => new Date(event.startDate).toDateString() === date.toDateString());
+        }
 
-        // 기존에 있는 일정 목록을 초기화
-        sidebar.empty();
+        // 클릭한 날짜에 해당하는 일정을 리스트 형식으로 보여주는 함수
+        function showEventsList(events) {
+            // 우측 사이드바에 있는 일정 목록을 참조
+            let sidebar = $('.area_agenda_info');
 
-        // 가져온 일정 데이터를 시작 시간을 기준으로 정렬
-        events.sort((a, b) => {
-            return new Date(a.start) - new Date(b.start);
-        });
+            // 기존에 있는 일정 목록을 초기화
+            sidebar.empty();
 
-        // 가져온 일정 데이터를 리스트 형식으로 추가
-        let ul = $('<ul>').addClass('events-list').css({
-            'display': 'flex',
-            'flex-direction': 'column'
-        });
-
-
-        events.forEach(event => {
-            let li = $('<li>').addClass('event-item');
-
-            // 시간 정보 추가
-            let dateTimeArray = event.start.split(' ');
-            let date = dateTimeArray[0]; // 날짜 부분
-            let full_time = dateTimeArray[1]; // 시간 부분  00:00
-            let TimeArray = full_time.split(':');
-            let hour = TimeArray[0];
-            let min = TimeArray[1];
-            let timeSpan = $('<span>').text(`${hour}:${min}`).addClass('event-time').css('margin-right', '3px');
-            li.append(timeSpan);
-
-            // 일정에 해당하는 카테고리의 색상 적용
-            let colorBar = $('<span>').addClass('color-bar').css({
-                'background-color': event.color,
-                'display': 'inline-block',
-                'width': '4px',
-                'margin-right': '5px',
-                'margin-left': '5px'
+            // 가져온 일정 데이터를 시작 시간을 기준으로 정렬
+            events.sort((a, b) => {
+                return new Date(a.start) - new Date(b.start);
             });
-            li.append(colorBar);
 
-            // 제목과 상세 정보 추가
-            let titleAndDetail = $('<div>').addClass('title-and-detail').css({
+            // 가져온 일정 데이터를 리스트 형식으로 추가
+            let ul = $('<ul>').addClass('events-list').css({
                 'display': 'flex',
-                'flex-direction': 'column',
-                'flex': '1'
-            });
-            let titleSpan = $('<span>').text(event.name).addClass('event-title').css('margin-bottom', '5px');
-            let detailSpan = $('<span>').text(event.propA).addClass('event-detail');
-            titleAndDetail.append(titleSpan, detailSpan);
-            li.append(titleAndDetail);
-
-            // 클릭 이벤트 추가
-            li.on('click', function () {
-                // 클릭한 날짜에 해당하는 캘린더 이벤트 선택
-                calendar.select(event.start);
+                'flex-direction': 'column'
             });
 
-            ul.append(li);
-        });
 
-        // 리스트를 우측 사이드바에 추가
-        sidebar.append(ul);
+            events.forEach(event => {
+                let li = $('<li>').addClass('event-item');
+
+                // 시간 정보 추가
+                let dateTimeArray = event.startDate.split(' ');
+                let date = dateTimeArray[0]; // 날짜 부분
+                let full_time = dateTimeArray[1]; // 시간 부분  00:00
+                let TimeArray = full_time.split(':');
+                let hour = TimeArray[0];
+                let min = TimeArray[1];
+                let timeSpan = $('<span>').text(`${hour}:${min}`).addClass('event-time').css('margin-right', '3px');
+                li.append(timeSpan);
+
+                // 일정에 해당하는 카테고리의 색상 적용
+                let colorBar = $('<span>').addClass('color-bar').css({
+                    'background-color': event.color,
+                    'display': 'inline-block',
+                    'width': '4px',
+                    'margin-right': '5px',
+                    'margin-left': '5px'
+                });
+                li.append(colorBar);
+
+                // 제목과 상세 정보 추가
+                let titleAndDetail = $('<div>').addClass('title-and-detail').css({
+                    'display': 'flex',
+                    'flex-direction': 'column',
+                    'flex': '1'
+                });
+                let titleSpan = $('<span>').text(event.name).addClass('event-title').css('margin-bottom', '5px');
+                let detailSpan = $('<span>').text(event.propA).addClass('event-detail');
+                titleAndDetail.append(titleSpan, detailSpan);
+                li.append(titleAndDetail);
+
+                // 클릭 이벤트 추가
+                li.on('click', function () {
+                    // 클릭한 날짜에 해당하는 캘린더 이벤트 선택
+                    calendar.select(event.startDate);
+                    console.log("눌림!");
+                });
+
+                ul.append(li);
+            });
+
+            // 리스트를 우측 사이드바에 추가
+            sidebar.append(ul);
+        }
     }
-});
 
-    // // 캘린더 div 참조
-    // let calendarEl = document.getElementById('calendar');
-    //
-    //
-    // let calendar = new FullCalendar.Calendar(calendarEl, {
-    //     timeZone: 'UTC',
-    //     themeSystem: 'bootstrap5',
-    //     initialView: 'dayGridMonth',
-    //     // contentHeight: 600,
-    //     editable: true,  //  드래그해서 수정 가능한지, 길게 확장도 가능
-    //     selectable: true,
-    //     navLinks: false,  //  요일이랑 날짜 클릭 시 일이나 주단위 보여주는 화면으로 넘어감
-    //     select: function (info) {
-    //         // 클릭한 날짜 정보를 콘솔에 출력
-    //         console.log('Clicked date:', info.start);
-    //         // -> 확인용 코드
-    //         console.log(info);
-    //         // 클릭한 날짜에 해당하는 일정 가져오기
-    //         let selectedDate = info.start;
-    //         let selectedEvents = getEventsForDate(selectedDate);
-    //
-    //         // console.log(selectedEvents)
-    //         // 가져온 일정을 리스트 형식으로 보여주기
-    //         showEventsList(selectedEvents);
-    //
-    //         // 클릭한 날짜를 tit_date에 표시
-    //         let clickedDate = selectedDate.toISOString().slice(0, 10); // YYYY-MM-DD 형식으로 변환
-    //         $('.tit_date').text(clickedDate);
-    //     },
-    //
-    //     headerToolbar: {
-    //         start: 'today prev,next',
-    //         center: 'title',
-    //         right: 'customDropdownMenu'
-    //     },
-    //
-    //     customButtons: {
-    //         customDropdownMenu: {
-    //             text: '전체',
-    //             click: function () {
-    //                 $('#customDropdownMenu').toggleClass('show');
-    //                 // $('#customDropdownMenu').empty(); // 이전 내용 지우기
-    //
-    //
-    //                 // drop down 메뉴 숨기는 함수
-    //                 function hideDropdownMenu() {
-    //                     $('#customDropdownMenu').removeClass('show');
-    //                 }
-    //
-    //                 // 일정 카테고리에 따라 일정 필터링하는 함수
-    //                 function filterEventsByCategory(category) {
-    //                     calendar.getEvents().forEach(function (event) {
-    //                         if (category === 'all') {
-    //                             event.setProp('display', 'block'); // 모든 일정 보이기
-    //                         } else {
-    //                             if (event.extendedProps.isGroup !== category) {
-    //                                 event.setProp('display', 'none'); // 해당 카테고리가 아닌 일정 숨기기
-    //                             } else {
-    //                                 event.setProp('display', 'block'); // 해당 카테고리의 일정 보이기
-    //                             }
-    //                         }
-    //                     });
-    //                 }
-    //
-    //                 // drop down 버튼 클릭 시 이벤트 처리
-    //                 $('#customDropdownMenu .dropdown-item').click(function (e) {
-    //                     e.preventDefault();
-    //                     let category = $(this).data('category');
-    //                     $('.btn-secondary').text($(this).text()); // drop down 버튼 텍스트 변경
-    //                     console.log(category)
-    //                     hideDropdownMenu(); // 드롭다운 메뉴 숨기기
-    //                     filterEventsByCategory(category); // 선택한 카테고리에 따라 일정 필터링
-    //                 });
-    //             }
-    //         }
-    //     },
-    //
-    //     initialDate: today, // 달력 처음 로드될 때 표시되는 날짜, default 는 현재 날짜
-    //     editable: false,
-    //     dayMaxEvents: true, // +more 표시 전 최대 이벤트 갯수, true는 셀 높이에 의해 결정
-    //     eventLimit: true,
-    //     // events: events.map(function (event) {
-    //     //     return {
-    //     //         title: event.name,
-    //     //         start: event.startDate,
-    //     //         backgroundColor: event.color,
-    //     //         textColor: "#ffffff"
-    //     //     };
-    //     // }),
-    //
-    // });
-    //
-    // calendar.render();
-    //
-    //
-    // // 클릭한 날짜에 해당하는 일정을 가져오는 함수
-    // function getEventsForDate(date) {
-    //     // 클릭한 날짜에 해당하는 일정 데이터를 필터링하여 반환
-    //
-    //     return events.filter(event => new Date(event.start).toDateString() === date.toDateString());
-    // }
-    //
-    // // 클릭한 날짜에 해당하는 일정을 리스트 형식으로 보여주는 함수
-    // function showEventsList(events) {
-    //     // 우측 사이드바에 있는 일정 목록을 참조
-    //     let sidebar = $('.area_agenda_info');
-    //
-    //     // 기존에 있는 일정 목록을 초기화
-    //     sidebar.empty();
-    //
-    //     // 가져온 일정 데이터를 시작 시간을 기준으로 정렬
-    //     events.sort((a, b) => {
-    //         return new Date(a.start) - new Date(b.start);
-    //     });
-    //
-    //     // 가져온 일정 데이터를 리스트 형식으로 추가
-    //     let ul = $('<ul>').addClass('events-list').css({
-    //         'display': 'flex',
-    //         'flex-direction': 'column'
-    //     });
-    //
-    //
-    //     events.forEach(event => {
-    //         let li = $('<li>').addClass('event-item');
-    //
-    //         // 시간 정보 추가
-    //         let dateTimeArray = event.start.split(' ');
-    //         let date = dateTimeArray[0]; // 날짜 부분
-    //         let full_time = dateTimeArray[1]; // 시간 부분  00:00
-    //         let TimeArray = full_time.split(':');
-    //         let hour = TimeArray[0];
-    //         let min = TimeArray[1];
-    //         let timeSpan = $('<span>').text(`${hour}:${min}`).addClass('event-time').css('margin-right', '3px');
-    //         li.append(timeSpan);
-    //
-    //         // 일정에 해당하는 카테고리의 색상 적용
-    //
-    //         let colorBar = $('<span>').addClass('color-bar').css({
-    //             'background-color': event.color,
-    //             'display': 'inline-block',
-    //             'width': '4px',
-    //             'margin-right': '5px',
-    //             'margin-left': '5px'
-    //         });
-    //         li.append(colorBar);
-    //
-    //         // 제목과 상세 정보 추가
-    //         let titleAndDetail = $('<div>').addClass('title-and-detail').css({
-    //             'display': 'flex',
-    //             'flex-direction': 'column',
-    //             'flex': '1'
-    //         });
-    //         let titleSpan = $('<span>').text(event.name).addClass('event-title').css('margin-bottom', '5px');
-    //         let detailSpan = $('<span>').text(event.propA).addClass('event-detail');
-    //         titleAndDetail.append(titleSpan, detailSpan);
-    //         li.append(titleAndDetail);
-    //
-    //         // 클릭 이벤트 추가
-    //         li.on('click', function () {
-    //             // 클릭한 날짜에 해당하는 캘린더 이벤트 선택
-    //             calendar.select(event.star);
-    //         });
-    //
-    //         ul.append(li);
-    //     });
-    //
-    //     // 리스트를 우측 사이드바에 추가
-    //     sidebar.append(ul);
-    // }
-    //
-    // // 이벤트 시작일을 포맷하는 함수
-    // function formatDateTime(date) {
-    //     let hours = date.getHours().toString().padStart(2, '0'); // 시간
-    //     let minutes = date.getMinutes().toString().padStart(2, '0'); // 분
-    //     return hours + ':' + minutes;
-    // }
-// })
+
+
+
+});
 

--- a/src/main/resources/static/js/inc/alarm.js
+++ b/src/main/resources/static/js/inc/alarm.js
@@ -1,0 +1,124 @@
+
+$("#alarmIcon").click(function () {
+    let icon = $(this);
+    let overlay = $(".overlay-container");
+
+    // 아이콘의 클래스를 토글하여 색상을 변경합니다.
+    icon.toggleClass("active-icon");
+
+    // 오버레이를 표시하거나 숨깁니다.
+    overlay.toggleClass("show-overlay");
+
+
+});
+
+// 데이터 배열
+let cardData = [
+    {
+        title: "밥약이용",
+        loc: "미정",
+        category: "category2",
+        startDate: "투표중",
+        startTime: "투표중",
+        voteEnd: "2024-05-11",
+    },
+    {
+        title: "술약이용",
+        loc: "미정",
+        category: "category1",
+        startDate: "투표중",
+        startTime: "투표중",
+        voteEnd: "2024-05-15",
+    },
+    {
+        title: "시험공부",
+        loc: "투표중",
+        category: "category3",
+        startDate: "2024-05-15",
+        startTime: "12:30",
+        voteEnd: "2024-05-15",
+    },
+    {
+        title: "시험공부",
+        loc: "혜화도서관",
+        category: "category3",
+        startDate: "2024-05-15",
+        startTime: "17:30",
+        voteEnd: "2024-05-15",
+    },
+    // 추가 데이터를 필요한 만큼 추가합니다.
+];
+
+let categoryColor = [
+    {
+        category1: "rgb(71, 147, 175)",
+        category2: "rgb(255, 196, 112)",
+        category3: "rgb(221, 87, 70)",
+        category4: "rgb(139, 50, 44)",
+    },
+];
+
+
+    let $msgOverlayListBubble = $(".msg-overlay-bubble-list");
+    cardData.forEach(function (card) {
+        let $cardOuter = $('<div class="card-outer"></div>');
+        let $cardName = $('<div class="card-name"></div>');
+        let $cardMain = $('<div class="card-main"></div>');
+        let $cardMain1 = $('<div class="card-main-1"></div>');
+        let $cardMain2 = $('<div class="card-main-2"></div>');
+        let $cardMain3 = $('<div class="card-main-3"></div>');
+
+        if (card.start === "투표중" && card.loc === "미정") {
+            $cardName.append("새로운 투표가 등록되었습니다");
+        } else if (card.loc === "투표중") {
+            $cardName.append("장소 투표를 진행 중입니다.");
+        } else if (
+            (card.start != "투표중" && card.loc != "미정") ||
+            (card.start != "투표중" && card.loc != "미정" && card.loc != "투표중")
+        ) {
+            $cardName.append("일정이 확정되었습니다.");
+        }
+
+        $cardMain1.append("<h3>" + card.title + "</h3>");
+        $cardMain3.append(
+            '<p><i class="bi bi-geo-alt"> </i>' + card.loc + "</p>"
+        );
+        // $cardMain1.append(
+        //     '<p class="highlight-category ' +
+        //     card.category +
+        //     '">' +
+        //     card.category +
+        //     "</p>"
+        // );
+
+        $cardMain1.append(
+            '<p class="highlight-category" style="background-color: ' +
+            categoryColor[0][card.category] +  // 카테고리에 해당하는 색상을 가져옵니다.
+            '; border-radius: 5px; padding: 3px;">' +
+            card.category +
+            "</p>"
+        );
+
+        $cardMain2.append(
+            '<p><i class="bi bi-calendar-check"> </i>' + card.startDate + "</p>"
+        );
+        $cardMain2.append(
+            '<p><i class="bi bi-clock"> </i>' + card.startTime + "</p>"
+        );
+        $cardMain3.append("<p>"+card.voteEnd + "투표 마감</p>");
+
+        // $cardMain.css('border-color', categoryColor[card.category]);
+        // let categoryBackgroundColor = categoryColor[card.category];
+        // $cardMain1.append('<h3>' + card.title + '</h3>');
+        $cardMain1.css("border-color", categoryColor);
+
+        if (card.category == categoryColor.category1)
+
+            $cardOuter.append($cardName);
+        $cardOuter.append($cardMain);
+        $cardMain.append($cardMain1);
+        $cardMain.append($cardMain2);
+        $cardMain.append($cardMain3);
+        $msgOverlayListBubble.append($cardOuter);
+    });
+

--- a/src/main/webapp/WEB-INF/views/calendar/calendar.jsp
+++ b/src/main/webapp/WEB-INF/views/calendar/calendar.jsp
@@ -1,10 +1,13 @@
 <%@ page language="java" contentType="text/html; charset=UTF-8"
 pageEncoding="UTF-8"%>
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
 <!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>main page</title>
     <!-- bootstrap css -->
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
@@ -14,12 +17,13 @@ pageEncoding="UTF-8"%>
     />
     <!-- FullCalendar -->
     <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.11/index.global.min.js"></script>
+
     <!-- bootstrap js-->
     <link
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
       rel="stylesheet"
       integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-      crossorigin="anonymous"
+      crossorigin="anonymous" defer
     />
     <!--bootstrap icon-->
     <link
@@ -27,8 +31,10 @@ pageEncoding="UTF-8"%>
       href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css"
     />
 
-    <link rel="stylesheet" href="css/calendar.css" />
-    <link rel="stylesheet" href="css/sidebar.css" />
+    <!-- jquery -->
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js" defer></script>
+
+    <link rel="stylesheet" href="/css/calendar.css" />
 
     <!--폰트-->
     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -38,36 +44,52 @@ pageEncoding="UTF-8"%>
       rel="stylesheet"
     />
     <!-- 사이드바 -->
-    <link rel="stylesheet" href="css/inc/sidebar.css" />
-    <script src="js/inc/sidebar.js" defer></script>
+    <link rel="stylesheet" href="/css/inc/sidebar.css" />
+    <script src="/js/inc/sidebar.js" defer></script>
+
+    <!-- 알람 -->
+    <link rel="stylesheet" href="/css/inc/alarm.css" />
+    <script src="/js/inc/alarm.js" defer></script>
+
+
+    <script src="/js/calendar.js" defer></script>
+<%--    <script--%>
+<%--            src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"--%>
+<%--            integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"--%>
+<%--            crossorigin="anonymous" defer--%>
+<%--    ></script>--%>
+
   </head>
 
   <body>
+<%--    <i class="bi bi-bell"></i>--%>
+
     <!-- 사이드바 include -->
     <jsp:include page="/WEB-INF/views/inc/sidebar.jsp">
       <jsp:param value="calendar" name="pageName" />
     </jsp:include>
+
+    <!-- 알람 include -->
+    <jsp:include page="/WEB-INF/views/inc/alarm.jsp">
+      <jsp:param value="calendar" name="scheduleName" />
+    </jsp:include>
+
     <div class="full-contentbox">
       <!--메인부분-->
       <div class="calAndSide">
-        <!--알람버튼 놓을 헤더 부분-->
-        <div class="headforbutton">
-          <button
-            id="myDropdownButton"
-            class="btn btn-secondary dropdown-toggle"
-            type="button"
-            data-bs-toggle="dropdown"
-            aria-expanded="false"
-          >
-            전체
-          </button>
-          <i class="bi bi-bell"></i>
-        </div>
 
         <!--달력과 우측 사이드가 들어갈 부분-->
         <div class="main">
           <!--달력이 들어갈 부분-->
           <div id="calendar"></div>
+
+
+          <!-- drop down -->
+          <div id="customDropdownMenu" class="dropdown-menu">
+            <a class="dropdown-item" href="#" data-category="all">c1</a>
+            <a class="dropdown-item" href="#" data-category="personal">c2</a>
+            <a class="dropdown-item" href="#" data-category="group">c3</a>
+          </div>
 
           <!--우측 사이드바가 들어갈 부분-->
           <div class="agenda_wrap">
@@ -84,12 +106,18 @@ pageEncoding="UTF-8"%>
       </div>
     </div>
 
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="js/calendar.js"></script>
-    <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
-      crossorigin="anonymous"
-    ></script>
+<%--    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>--%>
+<%--    <script src="/js/calendar.js"></script>--%>
+<%--    <script--%>
+<%--      src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"--%>
+<%--      integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"--%>
+<%--      crossorigin="anonymous"--%>
+<%--    ></script>--%>
+  <ul>
+    <li>
+      <li>
+
+    </li>
+  </ul>
   </body>
 </html>

--- a/src/main/webapp/WEB-INF/views/calendar/calendar.jsp
+++ b/src/main/webapp/WEB-INF/views/calendar/calendar.jsp
@@ -86,9 +86,9 @@ pageEncoding="UTF-8"%>
 
           <!-- drop down -->
           <div id="customDropdownMenu" class="dropdown-menu">
-            <a class="dropdown-item" href="#" data-category="all">c1</a>
-            <a class="dropdown-item" href="#" data-category="personal">c2</a>
-            <a class="dropdown-item" href="#" data-category="group">c3</a>
+            <a class="dropdown-item" href="#" data-category="all">전체 일정</a>
+            <a class="dropdown-item" href="#" data-category="personal">개인 일정</a>
+            <a class="dropdown-item" href="#" data-category="group">그룹 일정</a>
           </div>
 
           <!--우측 사이드바가 들어갈 부분-->

--- a/src/main/webapp/WEB-INF/views/inc/alarm.jsp
+++ b/src/main/webapp/WEB-INF/views/inc/alarm.jsp
@@ -1,0 +1,23 @@
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+
+
+  <i class="bi bi-bell" id="alarmIcon"></i>
+
+
+  <!--메세지함 overlay 구조-->
+  <div class="overlay-container">
+    <!-- <aside id="msg-overlay" class="msg-overlay-container"> -->
+    <div class="msg-overlay-bubble">
+      <header class="msg-overlay-bubble-header">
+        <p style="margin-top: 10px; font-weight: bold;">새로운 알람</p>
+      </header>
+      <section class="msg-overlay-bubble-list">
+        <!-- <div class="card-outer">
+          <div class="card-name"></div>
+          <div class="card-main"></div>
+        </div> -->
+      </section>
+    </div>
+    <!-- </aside> -->
+  </div>


### PR DESCRIPTION
<!--

PR 제목 예시

title : [feat] 소셜 로그인 기능 구현

-->

## 구현 기능

- 메인페이지 캘린더에 서버에서 가져온 일정 나타내기
- 일정 카테고리 별(개인, 그룹, 전체) 필터 걸기 

## 관련 이슈

- Close #42 

## 세부 작업 내용

- [x] 일정 카테고리별로 필터링
- [x] 달력에 필터 기능 추가(드롭다운)
- [x] 알람 ui 수정

## 참고 사항

- 리뷰어에게 참고할만한 사항을 입력해주세요.
